### PR TITLE
Add log infrastructure to the tagging extension and clean up whitespaces

### DIFF
--- a/python/MooseDocs/extensions/tagging.py
+++ b/python/MooseDocs/extensions/tagging.py
@@ -2,9 +2,9 @@
 import os, re
 import pickle
 import logging
-from ..tree import tokens 
-from ..common import __init__ 
-from . import command 
+from ..tree import tokens
+from ..common import __init__
+from . import command
 import json
 import codecs
 """     Tagger ouputs to tags.txt found at: 'moose/python/MooseDocs/extensions'
@@ -12,25 +12,25 @@ import codecs
         This extension defines the tagger command: !tagger name path key:value.  Tagger will except a string that represents the markdown file that is associated with an arb. list of key:value pairs.
         Arb spacing is allowed after the name/markdown name, however only one space is allowed before the name/markdown.  Ex: !tagger name    k1:v1  ka:va thing1:thing2 is okay, but not
         !tagger  name.
-        
+
         Tagger checks that all linked moose pages are unique and will not allow duplicate namess in the dictionary.  Duplicate key value pairs are allowed.
-        
-        If moose is served and *.md is editied to change an existing !tagger command, recompiling will NOT pick up the change since the moose page is already in the dictionary.  To fix this rm tags.txt found 
-        in the 'moose/python/MooseDocs/extensions' and create a new one: vim tags.txt.  After compiling with the empty txt the changes will be up dated. Probably a best practice to do this before using the 
-        pkl to generate the database filtering system. 
-        
+
+        If moose is served and *.md is editied to change an existing !tagger command, recompiling will NOT pick up the change since the moose page is already in the dictionary.  To fix this rm tags.txt found
+        in the 'moose/python/MooseDocs/extensions' and create a new one: vim tags.txt.  After compiling with the empty txt the changes will be up dated. Probably a best practice to do this before using the
+        pkl to generate the database filtering system.
+
         Since tagger & database happen before moose is served !tagger in *.md must be saved before ./moosedocs.py build --serve for the name to appear in the database filtering system. However, saving
-        *.md with new !tagger will add it to the tags.txt.   
-        
+        *.md with new !tagger will add it to the tags.txt.
+
         Example Tagger command in *.md:
         !tagger geochem keyg:valg keychem:valuechem
 
         Example Output TagDictionary in tags.txt:
-        {"data": 
-        [{"name": "heatconduction", "path": "moose/modules/heat_conduction/doc/content/modules/heat_conduction/index.md", "key_vals": {"keyheat": "valheat", "key": "val", "key1": "val1"}}, 
-        {"name": "index", "path": "moose/modules/doc/content/index.md", "key_vals": {"key1": "val1", "keya": "val"}}, 
-        {"name": "index2", "path": "moose/modules/doc/content/index2.md", "key_vals": {"key1": "val1", "keya": "val", "thing1": "thing2"}}, 
-        {"name": "geochem", "path": "moose/modules/geochemistry/doc/content/modules/geochemistry/index.md", "key_vals": {"keyg": "valg", "keychem": "valuechem"}}, 
+        {"data":
+        [{"name": "heatconduction", "path": "moose/modules/heat_conduction/doc/content/modules/heat_conduction/index.md", "key_vals": {"keyheat": "valheat", "key": "val", "key1": "val1"}},
+        {"name": "index", "path": "moose/modules/doc/content/index.md", "key_vals": {"key1": "val1", "keya": "val"}},
+        {"name": "index2", "path": "moose/modules/doc/content/index2.md", "key_vals": {"key1": "val1", "keya": "val", "thing1": "thing2"}},
+        {"name": "geochem", "path": "moose/modules/geochemistry/doc/content/modules/geochemistry/index.md", "key_vals": {"keyg": "valg", "keychem": "valuechem"}},
         {"name": "vortex", "path": "moose/modules/level_set/doc/content/modules/level_set/example_vortex.md", "key_vals": {"keyvor": "valvor", "key": "val", "key1": "val1"}}]
         }  """
 
@@ -53,7 +53,7 @@ class TaggingExtension(command.CommandExtension):
     @property
     def database(self):
         return self._database
-        
+
 
 class TaggingCommand(command.CommandComponent):
     COMMAND= 'tagger'
@@ -63,16 +63,16 @@ class TaggingCommand(command.CommandComponent):
     def defaultSettings():
         settings = command.CommandComponent.defaultSettings()
         return settings
-    
+
     def createToken(self, parent, info, page, settings):
         name=info[2]
-        keylist=info[3].split()    
+        keylist=info[3].split()
         mpath=re.sub(r'^.*?moose/', 'moose/', page.source)
         EntryKeyValDict=[]
         for keys in keylist:
             key_vals=keys.split(':')
             EntryKeyValDict.append([key_vals[0],key_vals[1]])
-            
+
         PageData= {'name':name, "path":mpath, "key_vals":dict(EntryKeyValDict)}
         # UploadableEntry={'data':[]}
         # UploadableEntry['data'].append(PageData)
@@ -80,13 +80,13 @@ class TaggingCommand(command.CommandComponent):
         # print('UploadableEntry')
         # print(UploadableEntry)
         # print('\n')
-        
+
         # # Set storage location
         while "moose" not in os.listdir():
             os.chdir('../')
         os.chdir('moose/python/MooseDocs/extensions')
-        
-        # save the dictionary 
+
+        # save the dictionary
         first_flag=0  # if there are no elements in dict then logic is needed to include 1st entry since  TagDictionary == listed
         existing_dictionary=0
         try:
@@ -128,5 +128,5 @@ class TaggingCommand(command.CommandComponent):
 
             with open('tags.txt', 'wb') as f:
                 json.dump(TagDictionary, codecs.getwriter('utf-8')(f), ensure_ascii=False)
-            
+
         return info

--- a/python/MooseDocs/extensions/tagging.py
+++ b/python/MooseDocs/extensions/tagging.py
@@ -1,6 +1,7 @@
 # Writing an extension from scratch
 import os, re
 import pickle
+import logging
 from ..tree import tokens 
 from ..common import __init__ 
 from . import command 
@@ -32,6 +33,8 @@ import codecs
         {"name": "geochem", "path": "moose/modules/geochemistry/doc/content/modules/geochemistry/index.md", "key_vals": {"keyg": "valg", "keychem": "valuechem"}}, 
         {"name": "vortex", "path": "moose/modules/level_set/doc/content/modules/level_set/example_vortex.md", "key_vals": {"keyvor": "valvor", "key": "val", "key1": "val1"}}]
         }  """
+
+LOG = logging.getLogger(__name__)
 
 def make_extension(**kwargs):  #reqired extension
     return TaggingExtension(**kwargs)
@@ -103,7 +106,9 @@ class TaggingCommand(command.CommandComponent):
                 if PageData['name'] in d['name']:
                     existing_dictionary+=1
                     if existing_dictionary ==1 and first_flag==0:
-                        print('Existing / Not Adding Tag to name Dictionary: \n', PageData['name'])
+                        msg = "Tag already exists; not adding to 'name' dictionary: "
+                        msg += PageData['name']
+                        LOG.warning(msg)
                     break
 
 


### PR DESCRIPTION
@DempseyRogers1994 putting up a PR for this so you can integrate it into your branch. This should now display proper warnings when tags are being duplicated. 

Whitespace clean-up was done by VScode - I have that setting turned on to remove trailing ones on each line. 
